### PR TITLE
Latest blog posts and upcoming meetings blocks

### DIFF
--- a/app/cells/decidim/alternative_landing/content_blocks/base_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/base_cell.rb
@@ -6,6 +6,27 @@ module Decidim
       class BaseCell < Decidim::ViewModel
         include Decidim::SanitizeHelper
         include Decidim::TranslationsHelper
+
+        def participatory_spaces
+          @participatory_spaces ||= [
+            Decidim::Assembly.where(organization: current_organization),
+            Decidim::ParticipatoryProcess.where(organization: current_organization),
+            (Decidim::Conference.where(organization: current_organization) if defined? Decidim::Conference),
+            (Decidim::Consultation.where(organization: current_organization) if defined? Decidim::Consultation),
+            (Decidim::Election.where(organization: current_organization) if defined? Decidim::Election),
+            (Decidim::Initiative.where(organization: current_organization) if defined? Decidim::Initiative)
+          ].flatten.compact
+        end
+
+        def available_components(manifest_name)
+          Decidim::Component.published.where(participatory_space: participatory_spaces, manifest_name: manifest_name).map do |component|
+            ["#{translated_attribute(component.name)} (#{translated_attribute(component.participatory_space.title)})", component.id]
+          end.unshift [t(".all"), nil]
+        end
+
+        def component
+          @component ||= Decidim::Component.find_by(id: form.object.settings.try(:component_id))
+        end
       end
     end
   end

--- a/app/cells/decidim/alternative_landing/content_blocks/cover_full_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/cover_full_settings_form_cell.rb
@@ -3,7 +3,7 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class CoverFullSettingsFormCell < Decidim::ViewModel
+      class CoverFullSettingsFormCell < BaseCell
         alias form model
       end
     end

--- a/app/cells/decidim/alternative_landing/content_blocks/cover_half_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/cover_half_settings_form_cell.rb
@@ -3,7 +3,7 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class CoverHalfSettingsFormCell < Decidim::ViewModel
+      class CoverHalfSettingsFormCell < BaseCell
         alias form model
       end
     end

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts/show.erb
@@ -1,0 +1,13 @@
+<section class="wrapper-home latest-blog-posts home-section">
+  <div class="row">
+    <h3 class="section-heading">
+      <%= section_title %>
+      <%= section_link %>
+    </h3>
+    <div class="row small-up-1 medium-up-2 mediumlarge-up-3 large-up-3 card-grid">
+      <% posts.each do |post| %>
+        <%= cell "decidim/blogs/post", post %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts/show.erb
@@ -1,4 +1,4 @@
-<section class="wrapper-home latest-blog-posts home-section">
+<section class="alternative-landing latest-blog-posts">
   <div class="row">
     <h3 class="section-heading">
       <%= section_title %>

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
@@ -5,7 +5,7 @@ module Decidim
     module ContentBlocks
       # A cell to be rendered as a content block with the latest blog posts published
       # in a Decidim Organization.
-      class LatestBlogPostsCell < Decidim::ViewModel
+      class LatestBlogPostsCell < BaseCell
         include Decidim::Core::Engine.routes.url_helpers
         include Decidim::Blogs::PostsHelper
 
@@ -21,7 +21,7 @@ module Decidim
 
         def posts
           @posts ||= Blogs::Post.where(
-            component: blog_components.find_by(id: model.settings.blog_id) || blog_components
+            component: blog_components.find_by(id: model.settings.component_id) || blog_components
           ).limit(posts_to_show).order(created_at: :desc)
         end
 

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      # A cell to be rendered as a content block with the latest blog posts published
+      # in a Decidim Organization.
+      class LatestBlogPostsCell < Decidim::ViewModel
+        include Decidim::Core::Engine.routes.url_helpers
+        include Decidim::Blogs::PostsHelper
+
+        def show
+          return if posts.empty?
+
+          render
+        end
+
+        def post_path(post)
+          Decidim::EngineRouter.main_proxy(post.component).post_path(post)
+        end
+
+        def posts
+          @posts ||= Blogs::Post.where(
+            component: blog_components.find_by(id: model.settings.blog_id) || blog_components
+          ).limit(posts_to_show).order(created_at: :desc)
+        end
+
+        private
+
+        # A MD5 hash of model attributes because is needed because
+        # it ensures the cache version value will always be the same size
+        def cache_hash
+          hash = []
+          hash << "decidim/content_blocks/latest_blog_posts"
+          hash << Digest::MD5.hexdigest(posts.map(&:cache_key_with_version).to_s)
+          hash << I18n.locale.to_s
+
+          hash.join("/")
+        end
+
+        def blog_components
+          @blog_components ||= Component.published.where(manifest_name: "blogs")
+        end
+
+        def posts_to_show
+          model.settings.count || 3
+        end
+
+        def section_title
+          translated_attribute model.settings.title
+        end
+
+        def section_link
+          link_to translated_attribute(model.settings.link_url) do
+            translated_attribute(model.settings.link_text)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
@@ -47,7 +47,7 @@ module Decidim
         end
 
         def section_title
-          translated_attribute model.settings.title
+          translated_attribute(model.settings.title).presence || t(".title")
         end
 
         def section_link

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form/show.erb
@@ -1,0 +1,14 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.translated :text_field, :title, label: t("decidim.alternative_landing.content_blocks.latest_blog_posts.title") %>
+  <%= settings_fields.translated :text_field, :link_text, label: t("decidim.alternative_landing.content_blocks.latest_blog_posts.link_text") %>
+  <%= settings_fields.translated :text_field, :link_url, label: t("decidim.alternative_landing.content_blocks.latest_blog_posts.link_url") %>
+  <%= settings_fields.number_field :count, label: t("decidim.alternative_landing.content_blocks.latest_blog_posts.count") %>
+
+  <% if blog %>
+    <p class="callout secondary">
+      <%= t("decidim.alternative_landing.content_blocks.latest_blog_posts.info", blog: translated_attribute(blog.name), space: translated_attribute(blog.participatory_space.title)) %>
+    </p>
+  <% end %>
+
+  <%= settings_fields.select :blog_id, available_blogs %>
+<% end %>

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form_cell.rb
@@ -3,29 +3,8 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class LatestBlogPostsSettingsFormCell < Decidim::ViewModel
+      class LatestBlogPostsSettingsFormCell < BaseCell
         alias form model
-
-        def blog
-          @blog ||= Decidim::Component.find_by(id: form.object.settings.try(:blog_id))
-        end
-
-        def available_blogs
-          Decidim::Component.where(participatory_space: participatory_spaces, manifest_name: "blogs").map do |blog|
-            ["#{translated_attribute(blog.name)} (#{translated_attribute(blog.participatory_space.title)})", blog.id]
-          end
-        end
-
-        def participatory_spaces
-          @participatory_spaces ||= [
-            Decidim::Assembly.where(organization: current_organization),
-            Decidim::ParticipatoryProcess.where(organization: current_organization),
-            (Decidim::Conference.where(organization: current_organization) if defined? Decidim::Conference),
-            (Decidim::Consultation.where(organization: current_organization) if defined? Decidim::Consultation),
-            (Decidim::Election.where(organization: current_organization) if defined? Decidim::Election),
-            (Decidim::Initiative.where(organization: current_organization) if defined? Decidim::Initiative)
-          ].flatten.compact
-        end
       end
     end
   end

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form_cell.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      class LatestBlogPostsSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def blog
+          @blog ||= Decidim::Component.find_by(id: form.object.settings.try(:blog_id))
+        end
+
+        def available_blogs
+          Decidim::Component.where(participatory_space: participatory_spaces, manifest_name: "blogs").map do |blog|
+            ["#{translated_attribute(blog.name)} (#{translated_attribute(blog.participatory_space.title)})", blog.id]
+          end
+        end
+
+        def participatory_spaces
+          @participatory_spaces ||= [
+            Decidim::Assembly.where(organization: current_organization),
+            Decidim::ParticipatoryProcess.where(organization: current_organization),
+            (Decidim::Conference.where(organization: current_organization) if defined? Decidim::Conference),
+            (Decidim::Consultation.where(organization: current_organization) if defined? Decidim::Consultation),
+            (Decidim::Election.where(organization: current_organization) if defined? Decidim::Election),
+            (Decidim::Initiative.where(organization: current_organization) if defined? Decidim::Initiative)
+          ].flatten.compact
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/alternative_landing/content_blocks/stack_horizontal_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/stack_horizontal_settings_form_cell.rb
@@ -3,7 +3,7 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class StackHorizontalSettingsFormCell < Decidim::ViewModel
+      class StackHorizontalSettingsFormCell < BaseCell
         alias form model
       end
     end

--- a/app/cells/decidim/alternative_landing/content_blocks/stack_vertical_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/stack_vertical_settings_form_cell.rb
@@ -3,7 +3,7 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class StackVerticalSettingsFormCell < Decidim::ViewModel
+      class StackVerticalSettingsFormCell < BaseCell
         alias form model
       end
     end

--- a/app/cells/decidim/alternative_landing/content_blocks/tiles_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/tiles_settings_form_cell.rb
@@ -3,7 +3,7 @@
 module Decidim
   module AlternativeLanding
     module ContentBlocks
-      class TilesSettingsFormCell < Decidim::ViewModel
+      class TilesSettingsFormCell < BaseCell
         alias form model
       end
     end

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings/show.erb
@@ -1,4 +1,4 @@
-<section class="wrapper-home upcoming-meetings home-section">
+<section class="alternative-landing upcoming-meetings">
   <div class="row">
     <h3 class="section-heading">
       <%= section_title %>
@@ -6,40 +6,7 @@
     </h3>
     <div class="row small-up-1 medium-up-2 mediumlarge-up-3 large-up-3 card-grid">
       <% meetings.each do |meeting| %>
-        <div class="column">
-          <div class="card card--meeting">
-            <% if meeting.photos.first.present? %>
-              <%= link_to resource_locator(meeting).path do %>
-                <%= image_tag meeting.photos.first.url, class: "card__image" %>
-              <% end %>
-            <% end %>
-            <div class="card__content">
-              <div class="card__header">
-                <%= link_to resource_locator(meeting).path, class: "card__link" do %>
-                  <h3 class="card__title">
-                    <%= translated_attribute meeting.title %>
-                  </h3>
-                <% end %>
-              </div>
-              <div class="card__text">
-                <% meeting_description = strip_tags(present(meeting).description.gsub("<br>", "\s")) %>
-                <%= truncate(meeting_description, length: 140, omission: "..." , escape: false) %>
-              </div>
-            </div>
-            <div class="card__icondata">
-              <ul class="card-data">
-                <li class="card-data__item">
-                  <%= icon "datetime", class: "icon--big" %>
-                </li>
-                <li class="card-data__item">
-                  <span class="time">
-                    <%= l meeting.start_time, format: "%a %d %B %H:%M" %>
-                  </span>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
+        <%= cell "decidim/meetings/meeting", meeting %>
       <% end %>
     </div>
   </div>

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings/show.erb
@@ -1,0 +1,52 @@
+<section class="wrapper-home upcoming-meetings home-section">
+  <div class="row">
+    <h3 class="section-heading">
+      <%= section_title %>
+      <%= section_link %>
+    </h3>
+    <div class="row small-up-1 medium-up-2 mediumlarge-up-3 large-up-3 card-grid">
+      <% meetings.each do |meeting| %>
+        <div class="column">
+          <div class="card card--meeting">
+            <% if meeting.photos.first.present? %>
+              <%= link_to resource_locator(meeting).path do %>
+                <%= image_tag meeting.photos.first.url, class: "card__image" %>
+              <% end %>
+            <% end %>
+            <div class="card__content">
+              <div class="card__header">
+                <%= link_to resource_locator(meeting).path, class: "card__link" do %>
+                  <h3 class="card__title">
+                    <%= translated_attribute meeting.title %>
+                  </h3>
+                <% end %>
+              </div>
+              <div class="card__text">
+                <% meeting_description = strip_tags(present(meeting).description.gsub("<br>", "\s")) %>
+                <%= truncate(meeting_description, length: 140, omission: "..." , escape: false) %>
+              </div>
+            </div>
+            <div class="card__icondata">
+              <ul class="card-data">
+                <li class="card-data__item">
+                  <%= icon "datetime", class: "icon--big" %>
+                </li>
+                <li class="card-data__item">
+                  <span class="time">
+                    <%= l meeting.start_time, format: "%a %d %B %H:%M" %>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>
+
+<script>
+$(document).ready(() => {
+  $(".card--meeting .card__text").find("img, iframe").remove()
+})
+</script>

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_cell.rb
@@ -49,7 +49,7 @@ module Decidim
         end
 
         def section_title
-          translated_attribute model.settings.title
+          translated_attribute(model.settings.title).presence || t(".title")
         end
 
         def section_link

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_cell.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      # A cell to be rendered as a content block with the upcoming meetings published
+      # in a Decidim Organization.
+      class UpcomingMeetingsCell < BaseCell
+        include Decidim::Core::Engine.routes.url_helpers
+        include Decidim::Meetings::Engine.routes.url_helpers
+        include Decidim::ApplicationHelper
+        include Decidim::IconHelper
+
+        def show
+          return if meetings.empty?
+
+          render
+        end
+
+        def meeting_path(meeting)
+          Decidim::EngineRouter.main_proxy(meeting.component).meeting_path(meeting)
+        end
+
+        def meetings
+          @meetings ||= Meetings::Meeting.upcoming.where(
+            component: meeting_component
+          ).limit(meetings_to_show).order(start_time: :asc)
+        end
+
+        private
+
+        # A MD5 hash of model attributes because is needed because
+        # it ensures the cache version value will always be the same size
+        def cache_hash
+          hash = []
+          hash << "decidim/content_blocks/upcoming_meetings"
+          hash << Digest::MD5.hexdigest(meetings.map(&:cache_key_with_version).to_s)
+          hash << I18n.locale.to_s
+
+          hash.join("/")
+        end
+
+        def meeting_component
+          @meeting_component ||= (Component.find_by(id: model.settings.component_id) || Component.where(manifest_name: "meetings"))
+        end
+
+        def meetings_to_show
+          model.settings.count || 3
+        end
+
+        def section_title
+          translated_attribute model.settings.title
+        end
+
+        def section_link
+          link_to translated_attribute(model.settings.link_url) do
+            translated_attribute(model.settings.link_text)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_settings_form/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_settings_form/show.erb
@@ -10,5 +10,5 @@
     </p>
   <% end %>
 
-  <%= settings_fields.select :component_id, available_components("blogs") %>
+  <%= settings_fields.select :component_id, available_components("meetings") %>
 <% end %>

--- a/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/upcoming_meetings_settings_form_cell.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      class UpcomingMeetingsSettingsFormCell < BaseCell
+        alias form model
+
+        def component
+          @component ||= Decidim::Component.find_by(id: form.object.settings.try(:component_id))
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,13 +18,14 @@ en:
           link_url: Link url
           title: Title
         latest_blog_posts:
-          blog_id: Blog ID
+          name: Latest blog posts
+        latest_blog_posts_settings_form:
+          all: Show posts from any blog
+          component_id: Blog component
           count: Number of items
-          info: Only posts from '%{blog}' in '%{space}' will be shown. You can change
-            it with the selector below.
+          info: Only posts from '%{component}' in '%{space}' will be shown. You can change it with the selector below.
           link_text: Link text
           link_url: Link URL
-          name: Latest blog posts
           title: Title
         stack_horizontal:
           name: Stack 3 (Horizontal)
@@ -51,3 +52,13 @@ en:
           body_n: 'Body #%{item_number}'
           title: Title
           title_n: 'Title #%{item_number}'
+        upcoming_meetings:
+          name: Upcoming meetings
+        upcoming_meetings_settings_form:
+          all: Show meetings from any space
+          component_id: Meetings component
+          count: Number of items
+          info: Only meetings from '%{component}' in '%{space}' will be shown. You can change it with the selector below.
+          link_text: Link text
+          link_url: Link URL
+          title: Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
           title: Title
         latest_blog_posts:
           name: Latest blog posts
+          title: Latest blog posts
         latest_blog_posts_settings_form:
           all: Show posts from any blog
           component_id: Blog component
@@ -54,6 +55,7 @@ en:
           title_n: 'Title #%{item_number}'
         upcoming_meetings:
           name: Upcoming meetings
+          title: Upcoming meetings
         upcoming_meetings_settings_form:
           all: Show meetings from any space
           component_id: Meetings component

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,15 @@ en:
           link_text: Link text
           link_url: Link url
           title: Title
+        latest_blog_posts:
+          blog_id: Blog ID
+          count: Number of items
+          info: Only posts from '%{blog}' in '%{space}' will be shown. You can change
+            it with the selector below.
+          link_text: Link text
+          link_url: Link URL
+          name: Latest blog posts
+          title: Title
         stack_horizontal:
           name: Stack 3 (Horizontal)
         stack_horizontal_settings_form:

--- a/lib/decidim/alternative_landing/engine.rb
+++ b/lib/decidim/alternative_landing/engine.rb
@@ -105,6 +105,21 @@ module Decidim
 
           content_block.images = 1.upto(4).map { |item_number| { name: :"background_image_#{item_number}", uploader: "Decidim::AlternativeLanding::ItemImageUploader" } }
         end
+
+        Decidim.content_blocks.register(:homepage, :latest_blog_posts) do |content_block|
+          content_block.cell = "decidim/alternative_landing/content_blocks/latest_blog_posts"
+          content_block.settings_form_cell = "decidim/alternative_landing/content_blocks/latest_blog_posts_settings_form"
+          content_block.public_name_key = "decidim.alternative_landing.content_blocks.latest_blog_posts.name"
+
+          content_block.settings do |settings|
+            settings.attribute :title, type: :text, translated: true
+            settings.attribute :link_text, type: :text, translated: true
+            settings.attribute :link_url, type: :text, translated: true
+            settings.attribute :count, type: :integer, default: 3
+            settings.attribute :blog_id, type: :integer
+          end
+        end
+
       end
 
       def initialize_content_block(scope, name, attributes: [], images: [], default: false)

--- a/lib/decidim/alternative_landing/engine.rb
+++ b/lib/decidim/alternative_landing/engine.rb
@@ -116,10 +116,23 @@ module Decidim
             settings.attribute :link_text, type: :text, translated: true
             settings.attribute :link_url, type: :text, translated: true
             settings.attribute :count, type: :integer, default: 3
-            settings.attribute :blog_id, type: :integer
+            settings.attribute :component_id, type: :integer
           end
         end
 
+        Decidim.content_blocks.register(:homepage, :upcoming_meetings) do |content_block|
+          content_block.cell = "decidim/alternative_landing/content_blocks/upcoming_meetings"
+          content_block.settings_form_cell = "decidim/alternative_landing/content_blocks/upcoming_meetings_settings_form"
+          content_block.public_name_key = "decidim.alternative_landing.content_blocks.upcoming_meetings.name"
+
+          content_block.settings do |settings|
+            settings.attribute :title, type: :text, translated: true
+            settings.attribute :link_text, type: :text, translated: true
+            settings.attribute :link_url, type: :text, translated: true
+            settings.attribute :count, type: :integer, default: 3
+            settings.attribute :component_id, type: :integer
+          end
+        end
       end
 
       def initialize_content_block(scope, name, attributes: [], images: [], default: false)

--- a/lib/decidim/alternative_landing/test/factories.rb
+++ b/lib/decidim/alternative_landing/test/factories.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/blogs/test/factories"
+require "decidim/meetings/test/factories"
 
 FactoryBot.define do
   factory :alternative_landing_content_block, parent: :content_block do
@@ -126,6 +128,30 @@ FactoryBot.define do
       end
 
       content_block.save!
+    end
+  end
+
+  factory :latest_blog_posts_block, parent: :alternative_landing_content_block do
+    manifest_name { :latest_blog_posts }
+
+    settings do
+      {
+        title: generate_localized_title,
+        link_text: Decidim::Faker::Localized.word,
+        link_url: Decidim::Faker::Localized.literal("https://decidim.org")
+      }
+    end
+  end
+
+  factory :upcoming_meetings_block, parent: :alternative_landing_content_block do
+    manifest_name { :upcoming_meetings }
+
+    settings do
+      {
+        title: generate_localized_title,
+        link_text: Decidim::Faker::Localized.word,
+        link_url: Decidim::Faker::Localized.literal("https://decidim.org")
+      }
     end
   end
 end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -20,6 +20,12 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
     let!(:stack_horizontal_block) { create(:stack_horizontal_block, organization: organization) }
     let!(:stack_vertical_block) { create(:stack_vertical_block, organization: organization) }
     let!(:tiles_block) { create(:tiles_block, organization: organization) }
+    let!(:latest_blog_posts_block) { create(:latest_blog_posts_block, organization: organization) }
+    let!(:upcoming_meetings_block) { create(:upcoming_meetings_block, organization: organization) }
+    let!(:blogs_component) { create(:component, manifest_name: "blogs", organization: organization) }
+    let!(:meetings_component) { create(:component, manifest_name: "meetings", organization: organization) }
+    let!(:blog_posts) { create_list(:post, 6, component: blogs_component) }
+    let!(:meetings) { create_list(:meeting, 6, :upcoming, component: meetings_component) }
 
     before do
       visit decidim.root_path
@@ -32,6 +38,8 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
       expect(page).to have_selector(".alternative-landing.stack-horizontal")
       expect(page).to have_selector(".alternative-landing.stack-vertical")
       expect(page).to have_selector(".alternative-landing.tiles-4")
+      expect(page).to have_selector(".alternative-landing.latest-blog-posts")
+      expect(page).to have_selector(".alternative-landing.upcoming-meetings")
     end
 
     describe "cover_full block" do
@@ -147,6 +155,36 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
                 end
               end
             end
+          end
+        end
+      end
+    end
+
+    describe "latest_blog_posts block" do
+      it "renders all elements" do
+        within ".alternative-landing.latest-blog-posts" do
+          expect(page).to have_i18n_content(latest_blog_posts_block.settings.title, upcase: true)
+          expect(page).to have_i18n_content(latest_blog_posts_block.settings.link_text, upcase: true)
+          blog_posts.last(3).each do |blog_post|
+            expect(page).to have_i18n_content(blog_post.title)
+          end
+          blog_posts.first(3).each do |blog_post|
+            expect(page).not_to have_i18n_content(blog_post.title)
+          end
+        end
+      end
+    end
+
+    describe "upcoming_meetings block" do
+      it "renders all elements" do
+        within ".alternative-landing.upcoming-meetings" do
+          expect(page).to have_i18n_content(upcoming_meetings_block.settings.title, upcase: true)
+          expect(page).to have_i18n_content(upcoming_meetings_block.settings.link_text, upcase: true)
+          meetings.last(3).each do |meeting|
+            expect(page).to have_i18n_content(meeting.title)
+          end
+          meetings.first(3).each do |meeting|
+            expect(page).not_to have_i18n_content(meeting.title)
           end
         end
       end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -26,6 +26,7 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
     let!(:meetings_component) { create(:component, manifest_name: "meetings", organization: organization) }
     let!(:blog_posts) { create_list(:post, 6, component: blogs_component) }
     let!(:meetings) { create_list(:meeting, 6, :upcoming, component: meetings_component) }
+    let!(:sorted_meetings) { meetings.sort_by(&:start_time).reverse }
 
     before do
       visit decidim.root_path
@@ -180,10 +181,10 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
         within ".alternative-landing.upcoming-meetings" do
           expect(page).to have_i18n_content(upcoming_meetings_block.settings.title, upcase: true)
           expect(page).to have_i18n_content(upcoming_meetings_block.settings.link_text, upcase: true)
-          meetings.last(3).each do |meeting|
+          sorted_meetings.last(3).each do |meeting|
             expect(page).to have_i18n_content(meeting.title)
           end
-          meetings.first(3).each do |meeting|
+          sorted_meetings.first(3).each do |meeting|
             expect(page).not_to have_i18n_content(meeting.title)
           end
         end


### PR DESCRIPTION
- Add latest blog posts content block
- Refactor content blocks, add upcoming meetings
- Simplify meetings card
- Add default title to sections
- Add specs for blog posts and meetings blocks

![image](https://user-images.githubusercontent.com/8806781/123792927-79584000-d8e1-11eb-9a23-c272ca2a40a2.png)

![image](https://user-images.githubusercontent.com/8806781/123792702-339b7780-d8e1-11eb-8a7c-e15b536a59c3.png)

![image](https://user-images.githubusercontent.com/8806781/123793020-90972d80-d8e1-11eb-9911-8c6ce0c9c3ec.png)

![image](https://user-images.githubusercontent.com/8806781/123792856-6180bc00-d8e1-11eb-975b-17a6fd297422.png)

