### PR TITLE
do not show unpublished components. delegate title in surveys to the questionnaire

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  RUBY_VERSION: 2.7.1
+  RUBY_VERSION: 2.7.4
 
 jobs:
   lint-report:
@@ -23,4 +23,4 @@ jobs:
       - name: Lint and Rubocop
         run: |
           bundle exec rubocop -P
-        # bundle exec erblint app/views/**/*.erb
+          bundle exec erblint app/**/*.erb

--- a/.github/workflows/test .yml
+++ b/.github/workflows/test .yml
@@ -6,16 +6,12 @@ on:
       - main
   pull_request:
 
+env:
+  RUBY_VERSION: 2.7.4
+
 jobs:
   test-report:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu]
-        ruby: [2.7]
-        decidim: [decidim-0.24]
-    runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -40,16 +36,17 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-        # do not use cache as appraisal is not compatible with gems installed locally
-
-      - name: Install Ruby deps
-        run: |
-          gem install bundler:2.1.4
-          bundle install  --jobs 4 --retry 3
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
 
       - name: Setup Database
         run: bundle exec rake test_app
-
+    
       - name: Run RSpec
-        run: SIMPLECOV=1 CODECOV=1 bundle exec rspec
+        run: SIMPLECOV=1 CODECOV=1 bundle exec rake
+
+      - uses: actions/upload-artifact@v2-preview
+        if: always()
+        with:
+          name: screenshots
+          path: ./spec/decidim_dummy_app/tmp/screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -850,7 +850,7 @@ DEPENDENCIES
   web-console (~> 3.5)
 
 RUBY VERSION
-   ruby 2.7.3p183
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,12 @@ task test_app: "decidim:generate_external_test_app" do
   ENV["RAILS_ENV"] = "test"
 end
 
+def seed_db(path)
+  Dir.chdir(path) do
+    system("bundle exec rake db:seed")
+  end
+end
+
 desc "Generates a development app."
 task :development_app do
   Bundler.with_original_env do
@@ -21,4 +27,6 @@ task :development_app do
       "--demo"
     )
   end
+
+  seed_db("development_app")
 end

--- a/app/cells/decidim/alternative_landing/content_blocks/calendar_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/calendar_cell.rb
@@ -16,8 +16,8 @@ module Decidim
           events.map do |event|
             {
               title: translated_attribute(event.full_title),
-              start: (event.start.strftime("%FT%R") unless event.start.nil?),
-              end: (event.finish.strftime("%FT%R") unless event.finish.nil?),
+              start: (event.start.strftime("%FT%R") if event.start.present?),
+              end: (event.finish.strftime("%FT%R") if event.finish.present?),
               color: event.color,
               url: event.link,
               resourceId: event.type,
@@ -30,7 +30,7 @@ module Decidim
         private
 
         def components
-          Decidim::Component.where(participatory_space: participatory_process_group.participatory_processes)
+          Decidim::Component.where(participatory_space: participatory_process_group.participatory_processes).published
         end
 
         def events
@@ -39,7 +39,7 @@ module Decidim
             query = if model.attribute_names.include?("decidim_component_id")
                       { component: components }
                     else
-                      { decidim_participatory_process_id: participatory_process_group.participatory_processes.pluck(:id) }
+                      { decidim_participatory_process_id: participatory_process_group.participatory_processes.published.pluck(:id) }
                     end
 
             model

--- a/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/latest_blog_posts_cell.rb
@@ -33,6 +33,7 @@ module Decidim
           hash = []
           hash << "decidim/content_blocks/latest_blog_posts"
           hash << Digest::MD5.hexdigest(posts.map(&:cache_key_with_version).to_s)
+          hash << "#{section_title}/#{section_link}"
           hash << I18n.locale.to_s
 
           hash.join("/")

--- a/app/controllers/concerns/decidim/alternative_landing/needs_content_blocks_snippets.rb
+++ b/app/controllers/concerns/decidim/alternative_landing/needs_content_blocks_snippets.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module AlternativeLanding
+    module NeedsContentBlocksSnippets
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :snippets
+      end
+
+      def snippets
+        return @snippets if @snippets
+
+        @snippets = Decidim::Snippets.new
+
+        @snippets.add(:alternative_landing, ActionController::Base.helpers.stylesheet_link_tag("decidim/alternative_landing/alternative_landing.css"))
+        @snippets.add(:head, @snippets.for(:alternative_landing))
+
+        @snippets
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/alternative_landing/calendar_event_presenter.rb
+++ b/app/presenters/decidim/alternative_landing/calendar_event_presenter.rb
@@ -41,6 +41,9 @@ module Decidim
         @link ||= case type
                   when "participatory_process_step"
                     Decidim::ResourceLocatorPresenter.new(participatory_process).url
+                  when "survey"
+                    # surveys aren't registered as resources, probably a bug in Decidim?
+                    Decidim::EngineRouter.main_proxy(__getobj__.component).root_path
                   else
                     Decidim::ResourceLocatorPresenter.new(__getobj__).url
                   end
@@ -79,6 +82,8 @@ module Decidim
         @full_title ||= case type
                         when "participatory_process_step"
                           participatory_process.title
+                        when "survey"
+                          questionnaire.title
                         else
                           title
                         end

--- a/lib/decidim/alternative_landing/engine.rb
+++ b/lib/decidim/alternative_landing/engine.rb
@@ -13,6 +13,11 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::AlternativeLanding
 
+      config.to_prepare do
+        Decidim::HomepageController.include(Decidim::AlternativeLanding::NeedsContentBlocksSnippets)
+        Decidim::ParticipatoryProcesses::ParticipatoryProcessGroupsController.include(Decidim::AlternativeLanding::NeedsContentBlocksSnippets)
+      end
+
       initializer "decidim_alternative_landing.snippets" do |app|
         app.config.enable_html_header_snippets = true
       end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -7,10 +7,17 @@ require "spec_helper"
 # file should be updated to match any change/bug fix introduced in the core
 checksums = [
   {
+    package: "decidim-core",
+    files: {
+      "/app/controllers/decidim/homepage_controller.rb" => "32b76eccc946735d60a4ae9244137bb2"
+    }
+  },
+  {
     package: "decidim-participatory_processes",
     files: {
       "/app/cells/decidim/participatory_process_groups/content_blocks/title_cell.rb" => "2f8ce513dbe5b2d9859a0f572cca1a76",
-      "/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb" => "60c3ce6c9868ae6d81e88530fca251e0"
+      "/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb" => "60c3ce6c9868ae6d81e88530fca251e0",
+      "/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb" => "1e564390ba85cc83aaef2a75b91c3b7f"
     }
   }
 ]


### PR DESCRIPTION
- [x] Fixes presenter for surveys (title is not present in the locator)
- [x] Finds url in surveys via main_proxy as this component is not registered as a resource in Decidim (probably a Decidim bug)
- [x] only shows published components/participatory spaces
- [x] Fixes cache for latests posts
- [x] Optimizes workflows