### PR TITLE
Add links to tiles

### DIFF
--- a/app/cells/decidim/alternative_landing/content_blocks/tiles_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/tiles_cell.rb
@@ -7,11 +7,19 @@ module Decidim
         def translated_title(item_number = nil)
           return translated_attribute(model.settings.title) if item_number.blank?
 
-          translated_attribute(model.settings.send("title_#{item_number}"))
+          if translated_url(item_number).blank?
+            translated_attribute(model.settings.send("title_#{item_number}"))
+          else
+            link_to translated_attribute(model.settings.send("title_#{item_number}")), translated_url(item_number)
+          end
         end
 
         def translated_body(item_number)
           translated_attribute(model.settings.send("body_#{item_number}"))
+        end
+
+        def translated_url(item_number)
+          translated_attribute(model.settings.send("link_url_#{item_number}"))
         end
 
         def background_image(item_number)

--- a/app/cells/decidim/alternative_landing/content_blocks/tiles_settings_form/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/tiles_settings_form/show.erb
@@ -6,6 +6,7 @@
       <div class="large-3 p-xs">
         <%= settings_fields.translated :text_field, :"title_#{item_number}", label: t(".title_n", item_number: item_number) %>
         <%= settings_fields.translated :text_area, :"body_#{item_number}", rows: 3, label: t(".body_n", item_number: item_number) %>
+        <%= settings_fields.translated :text_field, :"link_url_#{item_number}", label: t(".link_url_n", item_number: item_number) %>
       </div>
     <% end %>
   </div>

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/tiles.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/tiles.scss
@@ -23,6 +23,12 @@
       max-width: 20em;
       background: $alternative-color-1;
       padding: $gap;
+
+      h2 {
+        a {
+          color: $header-color;
+        }
+      }
     }
 
     &-heading {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
         tiles_settings_form:
           background_image_n: 'Background image for item #%{item_number}'
           body_n: 'Body #%{item_number}'
+          link_url_n: 'Link URL for item #%{item_number}'
           title: Title
           title_n: 'Title #%{item_number}'
         upcoming_meetings:

--- a/lib/decidim/alternative_landing/content_blocks/content_blocks_shared.rb
+++ b/lib/decidim/alternative_landing/content_blocks/content_blocks_shared.rb
@@ -96,6 +96,7 @@ require "decidim/alternative_landing"
       1.upto(4).map do |item_number|
         settings.attribute :"title_#{item_number}", type: :text, translated: true
         settings.attribute :"body_#{item_number}", type: :text, translated: true
+        settings.attribute :"link_url_#{item_number}", type: :text, translated: true
       end
     end
 

--- a/spec/shared/system_homepage_examples.rb
+++ b/spec/shared/system_homepage_examples.rb
@@ -110,6 +110,7 @@ shared_examples "render tiles block elements" do
             within ".tile-body" do
               expect(page).to have_i18n_content(tiles_block.settings.send(:"title_#{item_number}"))
               expect(page).to have_i18n_content(tiles_block.settings.send(:"body_#{item_number}"))
+              expect(page).to have_link(tiles_block.settings.send(:"body_#{item_number}")[I18n.locale]) if tiles_block.settings.send(:"link_url_#{item_number}").present?
             end
           end
         end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -55,6 +55,17 @@ describe "Visit the home page", type: :system, perform_enqueued: true do
 
     describe "tiles block" do
       it_behaves_like "render tiles block elements"
+
+      context "with link" do
+        before do
+          settings = tiles_block.settings
+          settings.link_url_1 = Decidim::Faker::Localized.literal(Faker::Internet.url)
+          tiles_block.settings = settings
+          tiles_block.save
+        end
+
+        it_behaves_like "render tiles block elements"
+      end
     end
 
     describe "latest_blog_posts block" do


### PR DESCRIPTION
Closes #47 

Allow to configure links in tiles:

<img width="1092" alt="Screenshot 2023-09-19 at 16 23 44" src="https://github.com/Platoniq/decidim-module-alternative_landing/assets/6973564/f9bb87db-dbd8-4d50-b475-958bea8060ea">

So the titles become links:

https://github.com/Platoniq/decidim-module-alternative_landing/assets/6973564/98f50f92-0c92-47c9-b470-33000366b006