### PR TITLE
Add new content_block: sidebar + 2 stack (meetings and posts)

### DIFF
--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
@@ -1,0 +1,82 @@
+<%
+  meetings = meetings()
+  posts = posts()
+%>
+
+<section class="alternative-landing sidebar-right-stack">
+  <div class="column_one p-[4rem]" style="background-image: url(<%= background_image %>); background-size: contain; background-repeat: no-repeat; background-size: 25% auto;
+  background-repeat: no-repeat;
+  background-position-y: bottom 6px;
+  background-position-x: right;">
+    <div>
+      <h2 class="text-[4rem] mt-4 mb-4 text-pretty uppercase font-bold">
+        <%= decidim_sanitize translated_title("sidebar") %>
+      </h2>
+    </div>
+    <div class="text-4xl w-2/3 text-balance">
+      <p><%= translated_body %></p>
+    </div>
+    <div>
+      <a href="<%= translated_url("sidebar")%>" class="button button__sm md:button__lg button__secondary no-underline mt-4">
+        <%= translated_link_text("sidebar") %>
+      </a>
+    </div>
+
+  </div>
+  <div class="column_two text-center ">
+    <div class="stack_one w-[50vw]">
+      <div class="w-[50vw]">
+        <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("meetings") %> </h2>
+      </div>
+      <div id="alternative-landing-sidebar-splide-meeting" class="splide w-[50vw] m-auto">
+        <div class="splide__slider">
+          <div class="splide__track">
+            <ul class="splide__list">
+              <% meetings.each do |meeting|%>
+                <li class="splide__slide meeting">
+                  <%
+                  formatted_date = l(meeting.start_time, format: :long)
+                  %>
+                  <h3 class="text-2xl"><%= translated_attribute(meeting.title) %></h3>
+                  <p><%= "#{formatted_date}" %></p>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <a href="<%= translated_url("meetings") %>" class="button button__sm md:button__lg button__secondary no-underline mt-4">
+          <%= translated_link_text("meetings") %>
+        </a>
+      </div>
+    </div>
+    <div class="stack_two w-[50vw]">
+      <div class="w-[50vw]">
+        <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("posts")%></h2>
+      </div>
+      <div id="alternative-landing-sidebar-splide-post"class="splide w-[50vw] m-auto">
+        <div class="splide__slider">
+          <div class="splide__track">
+            <ul class="splide__list">
+              <% posts.each do |post|%>
+                <li class="splide__slide post">
+                  <h3 class="text-2xl"><%= translated_attribute(post.title) %></h3>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <a href="<%= translated_url("posts") %>" class="button button__sm md:button__lg button__secondary no-underline mt-4">
+          <%= translated_link_text("posts") %>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%= append_javascript_pack_tag "decidim_splide" %>

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
@@ -3,8 +3,8 @@
   posts = posts()
 %>
 
-<section class="alternative-landing sidebar-right-stack flex flex-col md:grid md:grid-cols-2">
-  <div class="column_one h-[max(80vh, fit-content)] bg-no-repeat border-b-4 md:border-b-0 p-4 md:p-[4rem] md:border-r-4" style="background-image: url(<%= background_image %>);">
+<section class="alternative-landing sidebar-right-stack flex flex-col md:grid md:grid-cols-2 border-b-4">
+  <div class="column_one h-[max(80vh, fit-content)]  bg-no-repeat border-b-4 md:border-b-0 p-4 md:p-[4rem] md:border-r-4" style="background-image: url(<%= background_image %>);">
     <div>
       <h2 class="grid grid-cols-[1fr, 2fr, 1fr] text-5xl md:text-[4rem] md:mt-4 md:mb-4 text-pretty uppercase font-bold">
         <%= decidim_sanitize translated_title("sidebar") %>
@@ -21,7 +21,7 @@
 
   </div>
   <div class="column_two h-[max(80vh, fit-content)] text-center grid grid-rows-2">
-    <div class="stack_one w-[100vw] md:w-[50vw] border-b-4 grid grid-rows-3">
+    <div class="stack_one h-[40vh] w-[100vw] md:w-[50vw] border-b-4 grid grid-rows-3">
       <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("meetings") %> </h2>
       </div>
@@ -30,7 +30,7 @@
           <div class="splide__track">
             <ul class="splide__list">
               <% meetings.each do |meeting|%>
-                <li class="splide__slide meeting">
+                <li class="splide__slide min-h-[100px] ">
                   <%
                   formatted_date = l(meeting.start_time, format: :long)
                   %>
@@ -49,7 +49,7 @@
         </a>
       </div>
     </div>
-    <div class="stack_two w-[100vw] md:w-[50vw] grid grid-rows-3">
+    <div class="stack_two h-[40vh] w-[100vw] md:w-[50vw] grid grid-rows-3">
       <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("posts")%></h2>
       </div>

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
@@ -3,8 +3,8 @@
   posts = posts()
 %>
 
-<section class="alternative-landing sidebar-right-stack flex flex-col md:grid md:grid-cols-2 border-b-4">
-  <div class="column_one h-[max(80vh, fit-content)]  bg-no-repeat border-b-4 md:border-b-0 p-4 md:p-[4rem] md:border-r-4" style="background-image: url(<%= background_image %>);">
+<section class="home__section alternative-landing sidebar-right-stack flex flex-col md:grid md:grid-cols-2 !p-0">
+  <div class="column_one h-[max(80vh, fit-content)]  bg-no-repeat border-b-4 md:border-b-0 md:border-r-4 p-[3rem]" style="background-image: url(<%= background_image %>);">
     <div>
       <h2 class="grid grid-cols-[1fr, 2fr, 1fr] text-5xl md:text-[4rem] md:mt-4 md:mb-4 text-pretty uppercase font-bold">
         <%= decidim_sanitize translated_title("sidebar") %>
@@ -14,14 +14,14 @@
       <p><%= translated_body %></p>
     </div>
     <div>
-      <a href="<%= translated_url("sidebar")%>" class="button button__sm md:button__lg button__secondary no-underline mt-4">
+      <a href="<%= translated_url("sidebar")%>" class="button button__sm md:button__lg button__secondary no-underline mt-4 mb-4">
         <%= translated_link_text("sidebar") %>
       </a>
     </div>
 
   </div>
-  <div class="column_two h-[max(80vh, fit-content)] text-center grid grid-rows-2">
-    <div class="stack_one h-[40vh] w-[100vw] md:w-[50vw] border-b-4 grid grid-rows-3">
+  <div class="column_two h-[max(80vh, fit-content)] text-center flex flex-col">
+    <div class="stack_one h-[40vh] w-[100vw] md:w-[50vw] grid grid-rows-3">
       <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("meetings") %> </h2>
       </div>
@@ -49,6 +49,9 @@
         </a>
       </div>
     </div>
+
+    <hr class="h-[4px] bg-black" aria-role="presentation">
+
     <div class="stack_two h-[40vh] w-[100vw] md:w-[50vw] grid grid-rows-3">
       <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("posts")%></h2>
@@ -75,5 +78,6 @@
     </div>
   </div>
 </section>
+<hr class="h-[4px] bg-black" aria-role="presentation">
 
 <%= append_javascript_pack_tag "decidim_splide" %>

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack/show.erb
@@ -3,17 +3,14 @@
   posts = posts()
 %>
 
-<section class="alternative-landing sidebar-right-stack">
-  <div class="column_one p-[4rem]" style="background-image: url(<%= background_image %>); background-size: contain; background-repeat: no-repeat; background-size: 25% auto;
-  background-repeat: no-repeat;
-  background-position-y: bottom 6px;
-  background-position-x: right;">
+<section class="alternative-landing sidebar-right-stack flex flex-col md:grid md:grid-cols-2">
+  <div class="column_one h-[max(80vh, fit-content)] bg-no-repeat border-b-4 md:border-b-0 p-4 md:p-[4rem] md:border-r-4" style="background-image: url(<%= background_image %>);">
     <div>
-      <h2 class="text-[4rem] mt-4 mb-4 text-pretty uppercase font-bold">
+      <h2 class="grid grid-cols-[1fr, 2fr, 1fr] text-5xl md:text-[4rem] md:mt-4 md:mb-4 text-pretty uppercase font-bold">
         <%= decidim_sanitize translated_title("sidebar") %>
       </h2>
     </div>
-    <div class="text-4xl w-2/3 text-balance">
+    <div class="text-2xl md:text-4xl w-2/3 text-balance">
       <p><%= translated_body %></p>
     </div>
     <div>
@@ -23,12 +20,12 @@
     </div>
 
   </div>
-  <div class="column_two text-center ">
-    <div class="stack_one w-[50vw]">
-      <div class="w-[50vw]">
+  <div class="column_two h-[max(80vh, fit-content)] text-center grid grid-rows-2">
+    <div class="stack_one w-[100vw] md:w-[50vw] border-b-4 grid grid-rows-3">
+      <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("meetings") %> </h2>
       </div>
-      <div id="alternative-landing-sidebar-splide-meeting" class="splide w-[50vw] m-auto">
+      <div id="alternative-landing-sidebar-splide-meeting" class="splide w-[100vw] md:w-[50vw] m-auto">
         <div class="splide__slider">
           <div class="splide__track">
             <ul class="splide__list">
@@ -52,11 +49,11 @@
         </a>
       </div>
     </div>
-    <div class="stack_two w-[50vw]">
-      <div class="w-[50vw]">
+    <div class="stack_two w-[100vw] md:w-[50vw] grid grid-rows-3">
+      <div class="w-[100vw] md:w-[50vw]">
         <h2 class="mt-4 mb-4 text-5xl font-bold uppercase"><%= decidim_sanitize translated_title("posts")%></h2>
       </div>
-      <div id="alternative-landing-sidebar-splide-post"class="splide w-[50vw] m-auto">
+      <div id="alternative-landing-sidebar-splide-post"class="splide w-[100vw] md:w-[50vw] m-auto">
         <div class="splide__slider">
           <div class="splide__track">
             <ul class="splide__list">

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_cell.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      class SidebarRightStackCell < BaseCell
+        def translated_title(section)
+          translated_attribute(model.settings.send("title_#{section}"))
+        end
+
+        def translated_body
+          translated_attribute(model.settings.body)
+        end
+
+        def translated_link_text(section)
+          translated_attribute(model.settings.send("link_text_#{section}"))
+        end
+
+        def translated_url(section)
+          translated_attribute(model.settings.send("link_url_#{section}"))
+        end
+
+        def background_image
+          model.images_container.attached_uploader(:background_image).path(variant: :big)
+        end
+
+        def meetings
+          @meetings ||= Meetings::Meeting.upcoming.where(
+            component: component || components
+          )
+        end
+
+        def posts
+          @posts ||= Blogs::Post.where(
+            component: component || components
+          ).order(created_at: :desc)
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_settings_form/show.erb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_settings_form/show.erb
@@ -1,0 +1,39 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+
+  <h3><%= t(".settings_sidebar") %></h2>
+  <div class="grid-x">
+    <%= settings_fields.translated :text_field, :"title_sidebar", label: t(".title_sidebar") %>
+    <div class="large">
+      <%= settings_fields.translated :text_area, :"body", rows: 5, label: t(".body") %>
+    </div>
+    <div class="large">
+      <%= settings_fields.translated :text_field, :"link_text_sidebar", label: t(".link_text") %>
+      <%= settings_fields.translated :text_field, :"link_url_sidebar", label: t(".link_url") %>
+    </div>
+
+    <% form.fields_for :images, form.object.images do |images_fields| %>
+      <%= images_fields.upload :background_image, label: t(".image") %>
+    <% end %>
+  </div>
+
+  <h3><%= t(".settings_meetings") %></h2>
+  <div class="grid-x">
+    <%= settings_fields.translated :text_field, :"title_meetings", label: t(".title_meetings") %>
+    <div class="large">
+      <%= settings_fields.translated :text_field, :"link_text_meetings", label: t(".link_text") %>
+      <%= settings_fields.translated :text_field, :"link_url_meetings", label: t(".link_url") %>
+    </div>
+  </div>
+
+
+  <h3><%= t(".settings_posts") %></h2>
+  <div class="grid-x">
+    <%= settings_fields.translated :text_field, :"title_posts", label: t(".title_posts") %>
+    <div class="large">
+      <%= settings_fields.translated :text_field, :"link_text_posts", label: t(".link_text") %>
+      <%= settings_fields.translated :text_field, :"link_url_posts", label: t(".link_url") %>
+    </div>
+  </div>
+<% end %>
+
+

--- a/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_settings_form_cell.rb
+++ b/app/cells/decidim/alternative_landing/content_blocks/sidebar_right_stack_settings_form_cell.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AlternativeLanding
+    module ContentBlocks
+      class SidebarRightStackSettingsFormCell < Decidim::ViewModel
+        alias form model
+      end
+    end
+  end
+end

--- a/app/packs/entrypoints/decidim_splide.js
+++ b/app/packs/entrypoints/decidim_splide.js
@@ -1,0 +1,1 @@
+import "src/decidim/alternative_landing/decidim_splide";

--- a/app/packs/src/decidim/alternative_landing/decidim_splide.js
+++ b/app/packs/src/decidim/alternative_landing/decidim_splide.js
@@ -1,0 +1,14 @@
+import Splide from "@splidejs/splide";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const options =  {
+    type: "loop",
+    perPage: 1,
+    pagination: false,
+    width: "60%"
+  };
+
+  new Splide("#alternative-landing-sidebar-splide-meeting", options).mount();
+  new Splide("#alternative-landing-sidebar-splide-post", options).mount();
+});
+

--- a/app/packs/stylesheets/decidim/alternative_landing/alternative_landing.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/alternative_landing.scss
@@ -6,3 +6,4 @@
 @import "stylesheets/decidim/alternative_landing/content_blocks/stack_vertical";
 @import "stylesheets/decidim/alternative_landing/content_blocks/stack_horizontal";
 @import "stylesheets/decidim/alternative_landing/content_blocks/tiles";
+@import "stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack";

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
@@ -2,6 +2,8 @@
 @import "@splidejs/splide/dist/css/splide.min.css";
 
 .alternative-landing {
+  padding: 0;
+
   &.sidebar-right-stack {
     .column_one {
       background-position: bottom right;

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
@@ -1,0 +1,46 @@
+@import "stylesheets/decidim/alternative_landing/content_blocks/variables";
+@import "@splidejs/splide/dist/css/splide.min.css";
+
+.alternative-landing {
+  &.sidebar-right-stack {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+
+    height: 80vh;
+    border-top: 4px solid black;
+    border-bottom: 4px solid black;
+
+    .column_one {
+      display: grid;
+      grid-template-rows: 1fr 2fr 1fr;
+      height: 80vh;
+
+      border-right: 4px solid black
+    }
+
+    .column_two {
+      display: grid;
+      grid-template-rows: 1fr 1fr;
+      height: 80vh;
+
+      .stack_one {
+        border-bottom: 4px solid black;
+        height: 40vh;
+
+        display: grid;
+        grid-template-rows: repeat(3, 1fr);
+
+        .meeting {
+          min-height: 100px;
+        }
+      }
+      .stack_two {
+        display: grid;
+        grid-template-rows: repeat(3, 1fr);
+
+        height: 40vh;
+      }
+    }
+  }
+}
+

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
@@ -4,22 +4,8 @@
 .alternative-landing {
   &.sidebar-right-stack {
     .column_one {
-      background-position-y: bottom 6px;
-      background-position-x: right;
+      background-position: bottom right;
       background-size: 25%;
-    }
-
-    .column_two {
-      .stack_one {
-        height: 40vh;
-
-        .meeting {
-          min-height: 100px;
-        }
-      }
-      .stack_two {
-        height: 40vh;
-      }
     }
   }
 }

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
@@ -2,12 +2,20 @@
 @import "@splidejs/splide/dist/css/splide.min.css";
 
 .alternative-landing {
-  padding: 0;
-
   &.sidebar-right-stack {
     .column_one {
       background-position: bottom right;
       background-size: 25%;
+    }
+
+    .splide__arrow {
+      &.splide__arrow--prev {
+        left: -3em;
+      }
+
+      &.splide__arrow--next {
+        right: -3em;
+      }
     }
   }
 }

--- a/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
+++ b/app/packs/stylesheets/decidim/alternative_landing/content_blocks/sidebar_right_stack.scss
@@ -3,41 +3,21 @@
 
 .alternative-landing {
   &.sidebar-right-stack {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-
-    height: 80vh;
-    border-top: 4px solid black;
-    border-bottom: 4px solid black;
-
     .column_one {
-      display: grid;
-      grid-template-rows: 1fr 2fr 1fr;
-      height: 80vh;
-
-      border-right: 4px solid black
+      background-position-y: bottom 6px;
+      background-position-x: right;
+      background-size: 25%;
     }
 
     .column_two {
-      display: grid;
-      grid-template-rows: 1fr 1fr;
-      height: 80vh;
-
       .stack_one {
-        border-bottom: 4px solid black;
         height: 40vh;
-
-        display: grid;
-        grid-template-rows: repeat(3, 1fr);
 
         .meeting {
           min-height: 100px;
         }
       }
       .stack_two {
-        display: grid;
-        grid-template-rows: repeat(3, 1fr);
-
         height: 40vh;
       }
     }

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -21,5 +21,6 @@ Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_alternative_landing: "#{base_path}/app/packs/entrypoints/decidim_alternative_landing.js",
   decidim_fullcalendar: "#{base_path}/app/packs/entrypoints/decidim_fullcalendar.js",
+  decidim_splide: "#{base_path}/app/packs/entrypoints/decidim_splide.js",
   fullcalendar: "#{base_path}/app/packs/entrypoints/fullcalendar.js"
 )

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -76,6 +76,19 @@ ca:
           button_text: Text del botó
           consultations: Consultes
           title: Títol
+        sidebar_right_stack:
+          name: "Barra lateral + 2 items verticals (Trobades, Posts)"
+        sidebar_right_stack_settings_form:
+          settings_sidebar: "Barra lateral"
+          settings_meetings: "Trobades"
+          settings_posts: "Posts"
+          title_sidebar: "Títol per la barra lateral"
+          title_meetings: "Títol per les trobades"
+          title_posts: "Títol pels posts"
+          body: 'Text'
+          link_text: 'Text de l''enllaç'
+          link_url: 'URL de l''enllaç'
+          image: 'Imatge de fons'
         stack_horizontal:
           name: 3 Items configurables (Horitzontal)
         stack_horizontal_settings_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,19 @@ en:
           button_text: Button text
           consultations: Consultations
           title: Title
+        sidebar_right_stack:
+          name: "Sidebar + 2 items vertical (Meetings and Posts)"
+        sidebar_right_stack_settings_form:
+          settings_sidebar: "Sidebar"
+          settings_meetings: "Meetings"
+          settings_posts: "Posts"
+          title_sidebar: "Title for the sidebar"
+          title_meetings: "Title for the meetings"
+          title_posts: "Title for the posts"
+          body: "Content"
+          link_text: 'Link text'
+          link_url: 'Link URL'
+          image: 'Background image'
         stack_horizontal:
           name: Stack of 3 custom items (Horizontal)
         stack_horizontal_settings_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,18 +85,18 @@ en:
           consultations: Consultations
           title: Title
         sidebar_right_stack:
-          name: "Sidebar + 2 items vertical (Meetings and Posts)"
+          name: Sidebar + 2 items vertical (Meetings and Posts)
         sidebar_right_stack_settings_form:
-          settings_sidebar: "Sidebar"
-          settings_meetings: "Meetings"
-          settings_posts: "Posts"
-          title_sidebar: "Title for the sidebar"
-          title_meetings: "Title for the meetings"
-          title_posts: "Title for the posts"
-          body: "Content"
-          link_text: 'Link text'
-          link_url: 'Link URL'
-          image: 'Background image'
+          body: Content
+          image: Background image
+          link_text: Link text
+          link_url: Link URL
+          settings_meetings: Meetings
+          settings_posts: Posts
+          settings_sidebar: Sidebar
+          title_meetings: Title for the meetings
+          title_posts: Title for the posts
+          title_sidebar: Title for the sidebar
         stack_horizontal:
           name: Stack of 3 custom items (Horizontal)
         stack_horizontal_settings_form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -76,6 +76,27 @@ es:
           button_text: Texto del botón
           consultations: Consultas
           title: Título
+        sidebar_right_stack:
+          name: "Sidebar + Right Stack"
+        sidebar_right_stack_settings_form:
+          title_n: 'Título para el item #%{item_number}'
+          body_n: 'Texto para el item #%{item_number}'
+          link_text_n: 'Texto del enlace para el item #%{item_number}'
+          link_url_n: 'URL del enlace para el item #%{item_number}'
+          image: 'Imagen de fondo'
+        sidebar_right_stack:
+          name: "Barra lateral + 2 items verticales (Encuentros, Posts)"
+        sidebar_right_stack_settings_form:
+          settings_sidebar: "Barra lateral"
+          settings_meetings: "Encuentros"
+          settings_posts: "Publicaciones"
+          title_sidebar: "Título para la barra lateral"
+          title_meetings: "Título para los encuentros"
+          title_posts: "Título para los posts"
+          body: "Contenido"
+          link_text: 'Texto del enlace'
+          link_url: 'URL del enlace'
+          image: 'Imagen de fondo'
         stack_horizontal:
           name: 3 Items configurables (Horizontal)
         stack_horizontal_settings_form:

--- a/lib/decidim/alternative_landing/content_blocks/content_blocks_homepage.rb
+++ b/lib/decidim/alternative_landing/content_blocks/content_blocks_homepage.rb
@@ -15,5 +15,26 @@ def initialize_homepage_content_blocks
         settings.attribute :component_id, type: :integer
       end
     end
+
+    Decidim.content_blocks.register(:homepage, :sidebar_right_stack) do |content_block|
+      content_block.cell = "decidim/alternative_landing/content_blocks/sidebar_right_stack"
+      content_block.settings_form_cell = "decidim/alternative_landing/content_blocks/sidebar_right_stack_settings_form"
+      content_block.public_name_key = "decidim.alternative_landing.content_blocks.sidebar_right_stack.name"
+
+      content_block.settings do |settings|
+        settings.attribute :title_sidebar, type: :text, translated: true
+        settings.attribute :body, type: :text, translated: true
+        settings.attribute :link_text_sidebar, type: :text, translated: true
+        settings.attribute :link_url_sidebar, type: :text, translated: true
+        settings.attribute :title_meetings, type: :text, translated: true
+        settings.attribute :link_text_meetings, type: :text, translated: true
+        settings.attribute :link_url_meetings, type: :text, translated: true
+        settings.attribute :title_posts, type: :text, translated: true
+        settings.attribute :link_text_posts, type: :text, translated: true
+        settings.attribute :link_url_posts, type: :text, translated: true
+      end
+
+      content_block.images = [{ name: :background_image, uploader: "Decidim::AlternativeLanding::CoverImageUploader" }]
+    end
   end
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/core": "^6.0.2",
         "@fullcalendar/daygrid": "^6.0.2",
         "@fullcalendar/timegrid": "^6.0.2",
+        "@splidejs/splide": "^4.1.4",
         "codemirror": "^5.60.0",
         "foundation-sites": "^6.7.5"
       },
@@ -4644,6 +4645,11 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@splidejs/splide": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "node_modules/@stencil/core": {
       "version": "2.22.3",
@@ -21436,6 +21442,11 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "peer": true
+    },
+    "@splidejs/splide": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "@stencil/core": {
       "version": "2.22.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@fullcalendar/core": "^6.0.2",
     "@fullcalendar/daygrid": "^6.0.2",
     "@fullcalendar/timegrid": "^6.0.2",
+    "@splidejs/splide": "^4.1.4",
     "codemirror": "^5.60.0",
     "foundation-sites": "^6.7.5"
   }


### PR DESCRIPTION
Add a new content block.

This content block is divided in half, with the left section having:
- title
- body
- link button

And a right section divided vertically to have:
- meetings
	- title
	- link button
- posts
	- title
	- link button 

We have this content_block already deployed at https://noesfeinadedones.cat/

It might not be interesting for you, in that case we would move it to our instance, or keep it in our fork.